### PR TITLE
Apply Haldane–Anscombe adjustment for 2x2 chi-square

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ Optional:
 - Decoding metadata (`beam_used`, `top_p_used`, `objective`) to derive `strategy` in Step 07
 
 Each step skips gracefully if required columns are missing and still emits a tiny README for traceability.
+
+## Statistical utilities
+
+The helper `chi2_2x2` automatically applies the Haldane–Anscombe correction by
+adding 0.5 to all cells when zero counts occur before computing the
+chi-square test and odds ratio.
+
+The `holm_correction` helper adjusts a sequence of p-values using the
+Holm–Bonferroni method, and steps that emit per-model p-values include an
+additional `p_holm` column.
+
+The `proportion_tests` helper performs one-tailed (greater) z and exact
+binomial tests against a specified null proportion `p0`.

--- a/construal/common/preprocess.py
+++ b/construal/common/preprocess.py
@@ -125,14 +125,25 @@ def derive_design(df: pd.DataFrame, cfg: Config) -> pd.DataFrame:
             elif "src_order" in df.columns:
                 exp = df["src_order"].astype("string").map(expected_from_pl_order_str)
             
-            det = df[cfg.det_col].astype("string")
-            # Only score success for scorable pairs (both Def/Indef)
-            mask = det.isin(["Def", "Indef"]) & exp.isin(["Def", "Indef"])
-            
+            # ⬇️ Normalize both sides to lowercase (and strip, just in case)
+            det = df[cfg.det_col].astype("string").str.strip().str.lower()
+            exp = exp.astype("string").str.strip().str.lower()
+
+            # Only score success for scorable pairs (both def/indef)
+            valid = {"def", "indef"}
+            mask = det.isin(valid) & exp.isin(valid)
+
             # Create comparison
-            cmp_bool = (det == exp)
-            arr = np.where(mask, cmp_bool.fillna(False), np.nan)
-            df[cfg.success_col] = pd.Series(arr).map({True: 1, False: 0}).astype("Int64")
+            cmp_bool = det.eq(exp)
+            arr = np.where(
+                mask, cmp_bool.fillna(False).to_numpy(dtype=object), np.nan
+            )
+
+            df[cfg.success_col] = (
+                pd.Series(arr, index=df.index)
+                .map({True: 1, False: 0})
+                .astype("Int64")
+            )
             success_created = True
         
         # If we still couldn't create the success column, create a dummy one

--- a/construal/common/stats.py
+++ b/construal/common/stats.py
@@ -2,28 +2,66 @@ import numpy as np
 from scipy import stats
 from statsmodels.stats.proportion import proportions_ztest, binom_test as sm_binom_test
 from statsmodels.stats.contingency_tables import StratifiedTable
+from statsmodels.stats.multitest import multipletests
 from math import sqrt
 
+
+def holm_correction(pvals):
+    import numpy as np
+    p = np.asarray(list(pvals), dtype=float)
+    _, p_adj, _, _ = multipletests(p, method="holm")
+    return p_adj
+
 def proportion_tests(k: int, n: int, p0: float=0.5) -> dict:
-    stat, pz = proportions_ztest(k, n, value=p0)
+    stat, pz = proportions_ztest(k, n, value=p0, alternative="larger")
     try:
-        p_exact = sm_binom_test(k, n, prop=p0, alternative="two-sided")
+        p_exact = sm_binom_test(k, n, prop=p0, alternative="larger")
     except TypeError:
         from scipy.stats import binomtest
-        p_exact = binomtest(k, n, p=p0, alternative="two-sided").pvalue
+        p_exact = binomtest(k, n, p=p0, alternative="larger").pvalue
     return {"n": n, "k": k, "prop": k/n if n else np.nan, "z": float(stat), "p_z": float(pz), "p_exact": float(p_exact)}
 
-def chi2_2x2(a11,a12,a21,a22) -> dict:
-    table = np.array([[a11,a12],[a21,a22]], dtype=float)
+def chi2_2x2(a11, a12, a21, a22) -> dict:
+    """Chi-square test for a 2x2 contingency table.
+
+    Applies the Haldane–Anscombe correction (adds 0.5 to all cells) if any
+    cell in the table is zero. The chi-square test, odds ratio, and confidence
+    interval are computed from the (possibly corrected) table.
+
+    Returns a dictionary with the chi-square statistic, p-value, degrees of
+    freedom, odds ratio, confidence interval bounds, effect size (V), the
+    table total, and whether the correction was applied.
+    """
+
+    table = np.array([[a11, a12], [a21, a22]], dtype=float)
+    ha_correction = False
+    if (table == 0).any():
+        table += 0.5
+        ha_correction = True
+
     chi2, p, dof, _ = stats.chi2_contingency(table, correction=False)
-    table_ha = table + 0.5
-    or_est = (table_ha[0,0]*table_ha[1,1])/(table_ha[0,1]*table_ha[1,0])
-    se = sqrt(1/table_ha[0,0] + 1/table_ha[0,1] + 1/table_ha[1,0] + 1/table_ha[1,1])
-    ci_low = np.exp(np.log(or_est) - 1.96*se)
-    ci_hi  = np.exp(np.log(or_est) + 1.96*se)
+    or_est = (table[0, 0] * table[1, 1]) / (table[0, 1] * table[1, 0])
+    se = sqrt(
+        1 / table[0, 0]
+        + 1 / table[0, 1]
+        + 1 / table[1, 0]
+        + 1 / table[1, 1]
+    )
+    ci_low = np.exp(np.log(or_est) - 1.96 * se)
+    ci_hi = np.exp(np.log(or_est) + 1.96 * se)
     n = table.sum()
-    V = sqrt(chi2 / n) if n>0 else np.nan
-    return {"chi2":float(chi2), "p":float(p), "dof":int(dof), "or":float(or_est), "ci_low":float(ci_low), "ci_hi":float(ci_hi), "V":float(V), "n":int(n)}
+    V = sqrt(chi2 / n) if n > 0 else np.nan
+    return {
+        "chi2": float(chi2),
+        "p": float(p),
+        "dof": int(dof),
+        "or": float(or_est),
+        "ci_low": float(ci_low),
+        "ci_hi": float(ci_hi),
+        "V": float(V),
+        "n": int(n),
+        "ha_correction": ha_correction,
+    }
 
 def chi2_2x3(counts_2x3) -> dict:
     counts_2x3 = np.asarray(counts_2x3, dtype=float)

--- a/construal/steps/step03_determiner_dist.py
+++ b/construal/steps/step03_determiner_dist.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 from ..common.config import Config
 from ..common.io import write_table, write_text
-from ..common.stats import chi2_2x3, cmh_from_2x2_list
+from ..common.stats import chi2_2x3, cmh_from_2x2_list, chi2_2x2, holm_correction
 from ..common.tables import per_model_2x3
 
 def run(df: pd.DataFrame, cfg: Config):
@@ -23,21 +23,52 @@ def run(df: pd.DataFrame, cfg: Config):
     # Per-model 2×3
     rows = per_model_2x3(df, cfg.order_col, cfg.det_col, cfg.model_col)
     if rows:
-        write_table(pd.DataFrame(rows), f"{outdir}/step03_per_model_2x3.csv")
+        df_counts = pd.DataFrame(rows)
+        write_table(df_counts, f"{outdir}/step03_per_model_2x3.csv")
         outs.append({"kind":"csv","path":f"{outdir}/step03_per_model_2x3.csv"})
+
+        stats_rows = []
+        for r in rows:
+            table = [[r["SV_def"], r["SV_ind"], r["SV_none"]],
+                     [r["VS_def"], r["VS_ind"], r["VS_none"]]]
+            stats_rows.append({"model": r["model"], **chi2_2x3(table)})
+        df_stats = pd.DataFrame(stats_rows)
+        df_stats["p_holm"] = holm_correction(df_stats["p"].values)
+        write_table(df_stats, f"{outdir}/step03_per_model_2x3_stats.csv")
+        outs.append({"kind":"csv","path":f"{outdir}/step03_per_model_2x3_stats.csv"})
 
     # CMH contrasts (Def vs Others, Ind vs Others)
     tables_def, tables_ind = [], []
+    def_rows, ind_rows = [], []
     for m, g in df.groupby(cfg.model_col):
         g = g.copy()
         g["def_bin"] = (g[cfg.det_col] == "def").astype(int)
         ct2 = pd.crosstab(g[cfg.order_col], g["def_bin"]).reindex(index=["SV","VS"], columns=[0,1], fill_value=0)
         tables_def.append(ct2.values.astype(float))
 
+        sv_def = int(ct2.loc["SV",1]) if "SV" in ct2.index else 0
+        sv_oth = int(ct2.loc["SV",0]) if "SV" in ct2.index else 0
+        vs_def = int(ct2.loc["VS",1]) if "VS" in ct2.index else 0
+        vs_oth = int(ct2.loc["VS",0]) if "VS" in ct2.index else 0
+        res_def = chi2_2x2(sv_def, sv_oth, vs_def, vs_oth)
+        def_rows.append({"model": m, "SV_def": sv_def, "SV_others": sv_oth, "VS_def": vs_def, "VS_others": vs_oth, **res_def})
+
         g["ind_bin"] = (g[cfg.det_col] == "ind").astype(int)
         ct2i = pd.crosstab(g[cfg.order_col], g["ind_bin"]).reindex(index=["SV","VS"], columns=[0,1], fill_value=0)
         tables_ind.append(ct2i.values.astype(float))
 
+        sv_ind = int(ct2i.loc["SV",1]) if "SV" in ct2i.index else 0
+        sv_oth_i = int(ct2i.loc["SV",0]) if "SV" in ct2i.index else 0
+        vs_ind = int(ct2i.loc["VS",1]) if "VS" in ct2i.index else 0
+        vs_oth_i = int(ct2i.loc["VS",0]) if "VS" in ct2i.index else 0
+        res_ind = chi2_2x2(sv_ind, sv_oth_i, vs_ind, vs_oth_i)
+        ind_rows.append({"model": m, "SV_ind": sv_ind, "SV_others": sv_oth_i, "VS_ind": vs_ind, "VS_others": vs_oth_i, **res_ind})
+
+    if def_rows:
+        df_def = pd.DataFrame(def_rows)
+        df_def["p_holm"] = holm_correction(df_def["p"].values)
+        write_table(df_def, f"{outdir}/step03_per_model_def_vs_others.csv")
+        outs.append({"kind":"csv","path":f"{outdir}/step03_per_model_def_vs_others.csv"})
     if tables_def:
         try:
             cmh_def = cmh_from_2x2_list(tables_def)
@@ -46,6 +77,11 @@ def run(df: pd.DataFrame, cfg: Config):
         except Exception as e:
             write_text(f"CMH (def vs others) failed: {e}", f"{outdir}/step03_cmh_def_vs_others.txt")
             outs.append({"kind":"txt","path":f"{outdir}/step03_cmh_def_vs_others.txt"})
+    if ind_rows:
+        df_ind = pd.DataFrame(ind_rows)
+        df_ind["p_holm"] = holm_correction(df_ind["p"].values)
+        write_table(df_ind, f"{outdir}/step03_per_model_ind_vs_others.csv")
+        outs.append({"kind":"csv","path":f"{outdir}/step03_per_model_ind_vs_others.csv"})
     if tables_ind:
         try:
             cmh_ind = cmh_from_2x2_list(tables_ind)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,0 +1,21 @@
+import sys
+import pathlib
+import pandas as pd
+import pandas.testing as pdt
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from construal.common.preprocess import derive_design
+from construal.common.config import Config
+
+
+def test_determinacy_comparison_normalizes_strings():
+    df = pd.DataFrame({
+        'src_order': ['SUBJ_before_ROOT', 'ROOT_before_SUBJ', 'ROOT_before_SUBJ', 'SUBJ_before_ROOT'],
+        'det_cat': ['Def', 'indef', 'IND', '   DEF  '],
+        'model': ['m', 'm', 'm', 'm'],
+    })
+    cfg = Config(in_path=pathlib.Path('in'), out_dir=pathlib.Path('out'))
+    result = derive_design(df, cfg)
+
+    expected = pd.Series([1, 1, pd.NA, 1], name=cfg.success_col, dtype="Int64")
+    pdt.assert_series_equal(result[cfg.success_col], expected)

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,1 +1,47 @@
-def test_stats(): assert True
+import sys
+import pathlib
+import numpy as np
+from math import isclose
+from scipy import stats
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from construal.common.stats import chi2_2x2, holm_correction, proportion_tests
+from statsmodels.stats.proportion import proportions_ztest, binom_test as sm_binom_test
+
+
+def test_chi2_2x2_no_correction():
+    res = chi2_2x2(1, 2, 3, 4)
+    assert res["ha_correction"] is False
+    table = np.array([[1, 2], [3, 4]], dtype=float)
+    chi2, p, dof, _ = stats.chi2_contingency(table, correction=False)
+    assert isclose(res["chi2"], chi2)
+    assert isclose(res["p"], p)
+    assert res["dof"] == dof
+
+
+def test_chi2_2x2_haldane_anscombe():
+    res = chi2_2x2(1, 0, 3, 4)
+    assert res["ha_correction"] is True
+    table = np.array([[1, 0], [3, 4]], dtype=float)
+    table += 0.5
+    chi2, p, dof, _ = stats.chi2_contingency(table, correction=False)
+    assert isclose(res["chi2"], chi2)
+    expected_or = (table[0, 0] * table[1, 1]) / (table[0, 1] * table[1, 0])
+    assert isclose(res["or"], expected_or)
+
+
+def test_holm_correction_matches_statsmodels():
+    pvals = [0.01, 0.04, 0.03]
+    adj = holm_correction(pvals)
+    from statsmodels.stats.multitest import multipletests
+    _, expected, _, _ = multipletests(pvals, method="holm")
+    assert np.allclose(adj, expected)
+
+
+def test_proportion_tests_one_tailed():
+    res = proportion_tests(7, 10, p0=0.5)
+    stat, pz = proportions_ztest(7, 10, value=0.5, alternative="larger")
+    p_exact = sm_binom_test(7, 10, prop=0.5, alternative="larger")
+    assert isclose(res["z"], stat)
+    assert isclose(res["p_z"], pz)
+    assert isclose(res["p_exact"], p_exact)

--- a/tests/test_step03_holm.py
+++ b/tests/test_step03_holm.py
@@ -1,0 +1,35 @@
+import sys
+import pathlib
+from pathlib import Path
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+from construal.steps.step03_determiner_dist import run as step03_run
+from construal.common.config import Config
+
+
+def test_step03_per_model_p_holm(tmp_path):
+    data = [
+        {"order_cond": "SV", "det_cat": "def", "model": "m1"},
+        {"order_cond": "SV", "det_cat": "ind", "model": "m1"},
+        {"order_cond": "VS", "det_cat": "def", "model": "m1"},
+        {"order_cond": "VS", "det_cat": "none", "model": "m1"},
+        {"order_cond": "SV", "det_cat": "def", "model": "m2"},
+        {"order_cond": "SV", "det_cat": "none", "model": "m2"},
+        {"order_cond": "VS", "det_cat": "ind", "model": "m2"},
+        {"order_cond": "VS", "det_cat": "none", "model": "m2"},
+    ]
+    df = pd.DataFrame(data)
+    cfg = Config(in_path=Path("dummy"), out_dir=tmp_path)
+    step03_run(df, cfg)
+    stats_path = tmp_path / "step03_per_model_2x3_stats.csv"
+    assert stats_path.exists()
+    df_stats = pd.read_csv(stats_path)
+    assert "p_holm" in df_stats.columns
+    def_path = tmp_path / "step03_per_model_def_vs_others.csv"
+    ind_path = tmp_path / "step03_per_model_ind_vs_others.csv"
+    assert def_path.exists() and ind_path.exists()
+    df_def = pd.read_csv(def_path)
+    df_ind = pd.read_csv(ind_path)
+    assert "p_holm" in df_def.columns
+    assert "p_holm" in df_ind.columns


### PR DESCRIPTION
## Summary
- Adjust `chi2_2x2` to add 0.5 to contingency tables with zero cells before computing statistics and return a flag when applied
- Document the automatic Haldane–Anscombe correction in the README
- Add Holm–Bonferroni helper and wire `p_holm` columns into per-model determiner tests
- Normalize determinacy comparison strings in preprocessing to handle casing/whitespace discrepancies
- Run `proportion_tests` as a one-tailed (greater) comparison and document the behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1ca3cea20832dba1c2c951608523f